### PR TITLE
Add embedded Stripe checkout

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -718,33 +718,12 @@
         // Checkout Button Event Listener
         const checkoutButton = document.querySelector(".checkout-btn");
         if (checkoutButton) {
-          checkoutButton.addEventListener("click", async function () {
+          checkoutButton.addEventListener("click", function () {
             if (cart.length === 0) {
               alert("Your cart is empty. Please add items before checking out.");
               return;
             }
-
-            try {
-              const response = await fetch('/create-checkout-session', {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ cart: cart }), // Send the cart data
-              });
-
-              if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.error || 'Failed to create checkout session');
-              }
-
-              const session = await response.json();
-              // Redirect to Stripe Checkout
-              window.location.href = session.url;
-            } catch (error) {
-              console.error("Checkout error:", error);
-              alert("Could not proceed to checkout: " + error.message);
-            }
+            window.location.href = "checkout.html";
           });
         }
 

--- a/checkout.html
+++ b/checkout.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Checkout | Oh My Mochi</title>
+  <script src="https://js.stripe.com/v3/"></script>
+  <style>
+    body {
+      font-family: Helvetica, Arial, sans-serif;
+      padding: 40px 20px;
+    }
+    #checkout {
+      max-width: 600px;
+      margin: 0 auto;
+    }
+  </style>
+</head>
+<body>
+  <div id="checkout"></div>
+  <script>
+    async function initCheckout() {
+      const cart = JSON.parse(localStorage.getItem('shoppingCart')) || [];
+      if (cart.length === 0) {
+        alert('Your cart is empty.');
+        window.location.href = 'shop.html';
+        return;
+      }
+      const configRes = await fetch('/config');
+      const { publishableKey } = await configRes.json();
+      const stripe = Stripe(publishableKey);
+      const sessionRes = await fetch('/create-checkout-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cart })
+      });
+      const { clientSecret } = await sessionRes.json();
+      const elements = stripe.elements({ clientSecret });
+      const checkoutElement = elements.create('checkout');
+      checkoutElement.mount('#checkout');
+    }
+    initCheckout();
+  </script>
+</body>
+</html>

--- a/order-success.html
+++ b/order-success.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Order Successful</title>
+  <style>
+    body {
+      font-family: Helvetica, Arial, sans-serif;
+      padding: 40px 20px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <h2>Thank you for your order!</h2>
+  <p>We received your purchase and will contact you with pickup details soon.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update server to support Stripe Embedded Checkout
- create embedded checkout page and success page
- simplify checkout button on cart page to route to embedded checkout

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684473464cf8832c836c664cd0af9079